### PR TITLE
musl compat: replace sys/unistd.h with unistd.h

### DIFF
--- a/picosat.c
+++ b/picosat.c
@@ -8242,7 +8242,7 @@ picosat_stats (PS * ps)
 #ifndef NGETRUSAGE
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <sys/unistd.h>
+#include <unistd.h>
 #endif
 
 double


### PR DESCRIPTION
Building on alpine-linux (with musl) fails:
`picosat.c:8245:24: fatal error: sys/unistd.h: No such file or directory`
After the patch it is built and the tests run successfully
both on alpine and non-alpine systems.