### PR TITLE
Fix race condition around releasing the GIL and then calling the Python memory manager

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2017-10-29   0.6.3:
+-------------------
+  * Revert 'always use Python memory manager'
+
+
 2017-03-16   0.6.2:
 -------------------
   * update picosat to 965

--- a/pycosat.c
+++ b/pycosat.c
@@ -5,7 +5,7 @@
   uses an MIT style license.
 */
 #define PYCOSAT_URL  "https://pypi.python.org/pypi/pycosat"
-#define PYCOSAT_VERSION  "0.6.2"
+#define PYCOSAT_VERSION  "0.6.3"
 
 #include <Python.h>
 


### PR DESCRIPTION
.. by not calling the Python memory manager.